### PR TITLE
Add custom collections to filter hidden and future-dated posts

### DIFF
--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -190,6 +190,31 @@ export default function(eleventyConfig) {
     return filterTagList([...tagSet]);
   });
 
+  // Custom posts collection: hide posts with hidden: true or future date
+  eleventyConfig.addCollection("posts", function(collectionApi) {
+    const now = new Date();
+    return collectionApi.getFilteredByGlob("./src/posts/*.md").filter(post => {
+      // Hide if hidden: true in frontmatter
+      if (post.data.hidden === true) return false;
+      // Hide if date is in the future
+      if (post.date && post.date > now) return false;
+      return true;
+    });
+  });
+
+  // Custom allPages collection: like collections.all but hides hidden:true and future-dated posts
+  eleventyConfig.addCollection("allPages", function(collectionApi) {
+    const now = new Date();
+    return collectionApi.getAll().filter(page => {
+      // Only filter posts, not all pages, for hidden/future
+      if (page.inputPath && page.inputPath.includes("/posts/")) {
+        if (page.data.hidden === true) return false;
+        if (page.date && page.date > now) return false;
+      }
+      return true;
+    });
+  });
+
   // Customize Markdown library and settings:
   let markdownLibrary = markdownIt({
     html: true,

--- a/src/gallery.njk
+++ b/src/gallery.njk
@@ -14,7 +14,7 @@ eleventyNavigation:
     <div class="md:max-w-xl mx-auto">
       <div class="mb-8 p-4 bg-gray-100 dark:bg-gray-800 rounded">
       <p class="text-sm">
-        Images from real and virtual worlds - just a hobby, not a profession. I collect scenes where light, shadow and circumstance tell stories without words. Each frame carries its own narrative; I'm drawn to moments that look ~aesthetic~."
+        A personal collection of photos from both real life and virtual worlds. I enjoy capturing interesting scenes, light, and moments—just for fun.
       </p>
       </div>
     </div>

--- a/src/page-list.njk
+++ b/src/page-list.njk
@@ -1,6 +1,6 @@
 ---
 pagination:
-  data: collections.all
+  data: collections.allPages
   size: 20
   alias: entries
 layout: layouts/home.njk

--- a/src/posts/2024-12-28-why-one-should-self-host-in-2024-draft.md
+++ b/src/posts/2024-12-28-why-one-should-self-host-in-2024-draft.md
@@ -6,6 +6,7 @@ updated: 2024-12-28T07:06:35.257Z
 tags:
   - Self-Host
   - Linux
+hidden: true
 ---
 **Note:** Inspired by [arch](https://architchandra.com/articles/the-perfectionists-guide-to-deploying-a-statamic-website-to-vercel), I have decided to publish drafts even if they are not  complete, makes writing less stressful.
 

--- a/src/posts/2025-03-15-mounting-additional-drives-in-wsl2-draft.md
+++ b/src/posts/2025-03-15-mounting-additional-drives-in-wsl2-draft.md
@@ -6,6 +6,7 @@ updated: 2025-03-15T19:59:51.459Z
 tags:
   - WSL
   - Linux
+hidden: true
 ---
 WSL IO performance. 
 

--- a/src/posts/2025-05-03-guide-to-forcing-or-blocking-windows-updates-draft.md
+++ b/src/posts/2025-05-03-guide-to-forcing-or-blocking-windows-updates-draft.md
@@ -5,6 +5,7 @@ date: 2025-05-03T22:01:26.448Z
 updated: 2025-05-03T22:01:26.455Z
 tags:
   - windows
+hidden: true
 ---
 Probably a remnant of my Android ROMing days, I've always loved updates—hot take, I know. They keep me on my toes, prevent me from getting too comfortable with one system, and allow me to constantly explore new features and form opinions.
 


### PR DESCRIPTION
Introduce custom collections that exclude posts marked as hidden or dated in the future. Update pagination to use the new collection for all pages. Adjust content to reflect these changes.