### PR TITLE
feat: opt-in editorial post mode (drop cap, analysis, sidebar, wide tables, annotations)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14,6 +14,9 @@
 
 ### SEO & Navigation
 
+### Editorial Mode
+- [ ] Annotation comments should float into the right margin on xl+ screens but currently collide with the Outline / "Join the Conversation" sidebar. Today they stay inline on every breakpoint as a workaround. Options to explore: a per-post `marginalia: true` frontmatter that hides the right sidebar, a JS measurer that aligns comments to highlighted lines, or a layout that reserves a dedicated annotation gutter separate from the TOC. (2026-04-16)
+
 ### User Experience
 
 - [x] change all email references to carteakey.dev@gmail.com (2026-01-03)

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -1085,6 +1085,62 @@ export default function (eleventyConfig) {
     return `<code class="${langPrefix}">${markdownLibrary.utils.escapeHtml(token.content)}</code>`;
   };
 
+  // ═══════════════════════════════════════════════════════════════════════════
+  // 📰 Editorial shortcodes — minimal set
+  //   {% analysis %}  boxed section with title + optional winner pill
+  //   {% wide %}      full-bleed scrollable wrapper for wide tables
+  //   {% annotate %}  handwritten comment + squiggly arrow on highlighted text
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  const escapeHtml = (value) => String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+  const normalizeSide = (side) => (String(side || "").toLowerCase() === "b" ? "b" : "a");
+
+  const renderInnerMarkdown = (content) => {
+    if (!content || typeof content !== "string") return "";
+    const trimmed = content.replace(/^\s*\n/, "").replace(/\n\s*$/, "");
+    return markdownLibrary.render(trimmed);
+  };
+
+  // {% analysis title="Risk Comparison", winner="AAPL Lower Risk", side="a" %} markdown {% endanalysis %}
+  eleventyConfig.addPairedShortcode("analysis", function (content, opts = {}) {
+    const options = (opts && typeof opts === "object") ? opts : {};
+    const title = options.title ?? "";
+    const winner = options.winner;
+    const side = normalizeSide(options.side);
+    const winnerHtml = winner
+      ? `<span class="winner-badge" data-side="${side}">${escapeHtml(winner)}</span>`
+      : "";
+    const body = renderInnerMarkdown(content);
+    return `\n\n<section class="analysis-card" data-side="${side}">\n<header class="analysis-header"><h3 class="analysis-title">${escapeHtml(title)}</h3>${winnerHtml}</header>\n<div class="analysis-body">${body}</div>\n</section>\n\n`;
+  });
+
+  // {% wide %} markdown table (or anything wide) {% endwide %}
+  // Breaks out of article container; horizontally scrollable on mobile.
+  eleventyConfig.addPairedShortcode("wide", function (content) {
+    const body = renderInnerMarkdown(content);
+    return `\n\n<div class="wide-wrap not-prose">\n${body}\n</div>\n\n`;
+  });
+
+  // {% annotate "handwritten comment here" %}phrase to highlight{% endannotate %}
+  // Renders highlighted text with a Caveat-font note and squiggly arrow.
+  eleventyConfig.addPairedShortcode("annotate", function (content, comment) {
+    const safeComment = escapeHtml(comment || "");
+    return `<span class="note"><span class="note-target">${content}</span><span class="note-comment" aria-label="Note">${safeComment}</span></span>`;
+  });
+
+  // Render a string as markdown. Used by the sidebar partial so `sidebar.content:`
+  // frontmatter can contain real markdown instead of raw HTML.
+  eleventyConfig.addFilter("markdownify", function (str) {
+    if (!str || typeof str !== "string") return "";
+    return markdownLibrary.render(str);
+  });
+
   eleventyConfig.on("eleventy.after", async () => {
     const srcDir = path.resolve("src/posts");
     const destDirs = [path.resolve("_site/blog"), path.resolve("_site/posts")];

--- a/src/_includes/components/editorial-sidebar.njk
+++ b/src/_includes/components/editorial-sidebar.njk
@@ -1,0 +1,19 @@
+{# Optional sidebar panel — enabled via `sidebar:` frontmatter on a post.  #}
+{# Shape (all fields optional):                                             #}
+{#   sidebar:                                                               #}
+{#     label: "UPPER LABEL"                                                 #}
+{#     title: "Panel heading"                                               #}
+{#     content: |                                                           #}
+{#       Markdown content. Links, **bold**, bullet lists all work.          #}
+{#                                                                          #}
+{# `sidebar:` can also be a plain string — it gets rendered as markdown.    #}
+{% if sidebar %}
+{% set sidebarContent = sidebar.content if sidebar.content else (sidebar if sidebar is string else '') %}
+<section class="ed-sidebar-section not-prose">
+  {% if sidebar.label %}<span class="ed-sidebar-label">{{ sidebar.label }}</span>{% endif %}
+  {% if sidebar.title %}<h3 class="ed-sidebar-title">{{ sidebar.title }}</h3>{% endif %}
+  {% if sidebarContent %}
+  <div class="ed-sidebar-body">{{ sidebarContent | markdownify | safe }}</div>
+  {% endif %}
+</section>
+{% endif %}

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -19,7 +19,7 @@
   {# \u003cscript\u003ehljs.highlightAll();\u003c/script\u003e #}
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,200..800&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,200..800&family=Caveat:wght@400;500;700&display=swap" rel="stylesheet">
   <meta name="generator" content="Eleventy">
   <link id="prism-theme" href="/static/css/prism/prism-light.css" rel="stylesheet"/>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-DKK1XXJY42"></script>

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -42,12 +42,17 @@ hasEthicalAds: false
 {% set tocHtml = (content | toc) | default('') %}
 {% set conversationPlacement = conversationPlacement or 'sidebar' %}
 {% set showAds = false %}
+{% set isEditorial = (theme == 'editorial') %}
+{% set edPair = pair or 'teal-rose' %}
 
-<div class="relative mx-auto w-full ">
-  {# Left Sidebar - Author Card #}
+<div class="relative mx-auto w-full"{% if isEditorial %} data-pair="{{ edPair }}"{% endif %}>
+  {# Left Sidebar - Author Card (or editorial meta-sidebar) #}
   {% if showSidebar %}
   <aside class="hidden xl:block absolute -left-[280px] top-0">
     <div class="sticky top-24 w-[240px] space-y-4">
+      {% if isEditorial and sidebar %}
+        {% include "components/editorial-sidebar.njk" %}
+      {% endif %}
       {# Author Card #}
       <section class="border border-gray-200 dark:border-gray-800 rounded-xl p-5 text-center not-prose">
         <a href="/about" class="block group">
@@ -172,7 +177,11 @@ hasEthicalAds: false
     </div>
     {% endif %}
 
+    {% if isEditorial %}
+    <div class="ed-prose">{{ content | safe }}</div>
+    {% else %}
     {{ content | safe }}
+    {% endif %}
 
     {% if updated %}
       <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">

--- a/src/static/css/tailwind.css
+++ b/src/static/css/tailwind.css
@@ -1896,6 +1896,260 @@ picture img {
   }
 }
 
+/* ═══════════════════════════════════════════════════════════════════════════
+   📰 Editorial Mode — minimal opt-in layer
+   `theme: editorial` frontmatter gives a post:
+     • drop cap on the first paragraph
+     • optional free-form sidebar (via `sidebar:` frontmatter)
+   Companion shortcodes (work anywhere):
+     {% analysis %}  boxed section with title + optional winner pill
+     {% statblock %} dense two-row bar-fill metric card
+     {% wide %}      full-bleed scrollable wrapper for wide tables
+     {% annotate %}  handwritten-note callout with squiggly arrow
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+:root {
+  --accent-a: var(--accent-color);
+  --accent-b: color-mix(in srgb, var(--accent-color) 55%, #e11d48);
+}
+
+[data-pair="teal-rose"]      { --accent-a: #14b8a6; --accent-b: #e11d48; }
+[data-pair="orange-purple"]  { --accent-a: #f97316; --accent-b: #8b5cf6; }
+[data-pair="blue-amber"]     { --accent-a: #2563eb; --accent-b: #f59e0b; }
+[data-pair="emerald-rose"]   { --accent-a: #10b981; --accent-b: #f43f5e; }
+[data-pair="indigo-coral"]   { --accent-a: #6366f1; --accent-b: #fb7185; }
+
+@layer components {
+  /* ── Editorial wrapper: drop cap only, inherits everything else ── */
+  .ed-prose > p:first-of-type::first-letter {
+    font-family: var(--font-serif);
+    font-size: 3.1rem;
+    float: left;
+    line-height: 0.85;
+    font-weight: 700;
+    padding: 0.3rem 0.55rem 0 0;
+    color: var(--accent-a);
+  }
+
+  /* ── Analysis card ── */
+  .analysis-card {
+    border-radius: 0.75rem;
+    border: 1px solid rgb(229 231 235);
+    background-color: #fff;
+    padding: 1rem 1.1rem;
+    box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.04);
+    margin: 1.25em 0;
+  }
+
+  .dark .analysis-card {
+    border-color: rgb(39 39 42);
+    background-color: rgb(17 17 17);
+  }
+
+  @media (min-width: 640px) {
+    .analysis-card { padding: 1.25rem 1.5rem; }
+  }
+
+  .analysis-card[data-side="a"] { border-color: color-mix(in srgb, var(--accent-a) 30%, rgb(229 231 235)); }
+  .analysis-card[data-side="b"] { border-color: color-mix(in srgb, var(--accent-b) 30%, rgb(229 231 235)); }
+  .dark .analysis-card[data-side="a"] { border-color: color-mix(in srgb, var(--accent-a) 35%, rgb(39 39 42)); }
+  .dark .analysis-card[data-side="b"] { border-color: color-mix(in srgb, var(--accent-b) 35%, rgb(39 39 42)); }
+
+  .analysis-header {
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .analysis-header .analysis-title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: rgb(17 24 39);
+    letter-spacing: -0.005em;
+    margin: 0;
+  }
+
+  .dark .analysis-header .analysis-title { color: rgb(243 244 246); }
+
+  .analysis-header .winner-badge { margin-left: auto; }
+
+  .analysis-body { font-size: 0.95rem; line-height: 1.6; }
+  .analysis-body p { margin: 0 0 0.7em; }
+  .analysis-body p:last-child { margin-bottom: 0; }
+
+  /* ── Winner badge ── */
+  .winner-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-family: var(--font-mono);
+    font-size: 0.58rem;
+    text-transform: uppercase;
+    letter-spacing: 0.09em;
+    font-weight: 500;
+    padding: 0.2rem 0.55rem;
+    border-radius: 9999px;
+    border: 1px solid color-mix(in srgb, var(--accent-a) 40%, transparent);
+    background-color: color-mix(in srgb, var(--accent-a) 10%, transparent);
+    color: color-mix(in srgb, var(--accent-a) 80%, black);
+    white-space: nowrap;
+  }
+
+  .dark .winner-badge {
+    background-color: color-mix(in srgb, var(--accent-a) 20%, transparent);
+    color: color-mix(in srgb, var(--accent-a) 85%, white);
+  }
+
+  .winner-badge[data-side="b"] {
+    border-color: color-mix(in srgb, var(--accent-b) 40%, transparent);
+    background-color: color-mix(in srgb, var(--accent-b) 10%, transparent);
+    color: color-mix(in srgb, var(--accent-b) 80%, black);
+  }
+
+  .dark .winner-badge[data-side="b"] {
+    background-color: color-mix(in srgb, var(--accent-b) 20%, transparent);
+    color: color-mix(in srgb, var(--accent-b) 85%, white);
+  }
+
+  /* ── Sidebar (structure only — content flows from frontmatter) ── */
+  .ed-sidebar-section {
+    padding: 0.95rem 1rem;
+    border: 1px solid rgb(229 231 235);
+    border-radius: 0.5rem;
+    margin-bottom: 0.9rem;
+    font-size: 0.82rem;
+    line-height: 1.55;
+    background-color: color-mix(in srgb, var(--accent-a) 2%, #fff);
+  }
+
+  .dark .ed-sidebar-section {
+    border-color: rgb(39 39 42);
+    background-color: color-mix(in srgb, var(--accent-a) 4%, rgb(17 17 17));
+  }
+
+  .ed-sidebar-label {
+    font-family: var(--font-mono);
+    font-size: 0.58rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: rgb(107 114 128);
+    margin-bottom: 0.5rem;
+    display: block;
+  }
+
+  .dark .ed-sidebar-label { color: rgb(156 163 175); }
+
+  .ed-sidebar-title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    margin: 0 0 0.4rem;
+    color: rgb(17 24 39);
+  }
+
+  .dark .ed-sidebar-title { color: rgb(243 244 246); }
+
+  .ed-sidebar-body { color: rgb(55 65 81); }
+  .dark .ed-sidebar-body { color: rgb(209 213 219); }
+  .ed-sidebar-body p { margin: 0 0 0.5rem; }
+  .ed-sidebar-body p:last-child { margin-bottom: 0; }
+  .ed-sidebar-body a { color: var(--accent-a); text-decoration: underline; text-underline-offset: 2px; }
+
+  /* ── Wide table wrapper — breaks out of article container, sizes to content ── */
+  .wide-wrap {
+    width: 100vw;
+    max-width: 100vw;
+    margin-left: calc(50% - 50vw);
+    margin-right: calc(50% - 50vw);
+    padding: 0 clamp(1rem, 4vw, 3.5rem);
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    box-sizing: border-box;
+  }
+
+  /* Table sizes to its content, capped at the scroll container's padding-box */
+  .wide-wrap table {
+    margin: 1em auto;
+    width: auto;
+    max-width: 100%;
+    border-collapse: collapse;
+    font-size: 0.85rem;
+  }
+
+  .wide-wrap table th,
+  .wide-wrap table td {
+    padding: 0.5em 0.9em;
+    vertical-align: top;
+    max-width: 22rem;           /* cap any single cell so long prose wraps */
+    overflow-wrap: break-word;
+  }
+
+  .wide-wrap table th {
+    font-weight: 600;
+    text-align: left;
+    border-bottom: 2px solid rgb(229 231 235);
+    white-space: nowrap;        /* headers stay on one line */
+  }
+
+  .dark .wide-wrap table th { border-bottom-color: rgb(55 65 81); }
+
+  .wide-wrap table td { border-bottom: 1px solid rgb(243 244 246); }
+  .dark .wide-wrap table td { border-bottom-color: rgb(31 41 55); }
+
+  .wide-wrap table tbody tr:nth-child(even) { background: rgb(249 250 251 / 0.6); }
+  .dark .wide-wrap table tbody tr:nth-child(even) { background: rgb(24 24 27 / 0.4); }
+
+  /* ── {% annotate %} — highlighted phrase + handwritten comment + squiggly arrow ── */
+  /* Default (all viewports, any post): comment flows inline right after the highlight. */
+  .note {
+    position: relative;
+    display: inline;
+  }
+
+  .note-target {
+    background: color-mix(in srgb, var(--accent-color) 28%, transparent);
+    padding: 0 0.2em;
+    border-radius: 2px;
+    box-decoration-break: clone;
+    -webkit-box-decoration-break: clone;
+  }
+
+  .note-comment {
+    display: inline-block;
+    margin-left: 1.6em;
+    font-family: 'Caveat', 'Kalam', 'Comic Sans MS', cursive;
+    font-size: 1.1rem;
+    font-weight: 500;
+    line-height: 1.15;
+    color: var(--accent-color);
+    transform: rotate(-2deg);
+    vertical-align: baseline;
+    position: relative;
+    white-space: normal;
+    max-width: 16rem;
+  }
+
+  .note-comment::before {
+    content: '';
+    position: absolute;
+    right: calc(100% + 0.2em);
+    top: 0.2em;
+    width: 1.3em;
+    height: 1em;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 60 30' fill='none'%3E%3Cpath d='M2 24 Q 10 6, 22 14 Q 34 22, 52 4' stroke='currentColor' stroke-width='2.2' stroke-linecap='round' fill='none'/%3E%3Cpath d='M45 2 L54 4 L49 13' stroke='currentColor' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round' fill='none'/%3E%3C/svg%3E");
+    background-size: contain;
+    background-repeat: no-repeat;
+    transform: scaleX(-1);
+    opacity: 0.85;
+  }
+
+  /* TODO: on xl+ the right sidebar (Outline + comments) already occupies the    */
+  /* gutter, so annotations currently stay inline on every breakpoint.           */
+  /* Ideal future behaviour: absolute-position the comment into the right margin */
+  /* on wide screens, vertically tracking the highlighted line. Needs either a   */
+  /* per-post toggle for the sidebar, a JS measurer, or a layout rework.         */
+}
+
 /* ── Code block copy button ── */
 @layer components {
   .copy-code-btn {


### PR DESCRIPTION
## Summary
- Adds an opt-in `theme: editorial` frontmatter mode to posts, giving them a drop cap on the first paragraph, a free-form `sidebar:` panel, and a dual-accent color system (`--accent-a` / `--accent-b`, selectable via `data-pair` attribute with five curated pairs defaulting gracefully to the site accent).
- Ships three reusable Nunjucks shortcodes — `{% analysis %}` (boxed section with optional winner pill), `{% wide %}` (full-bleed wrapper for wide tables that breaks out of the article container and caps cells at 22rem so long prose wraps), `{% annotate %}` (highlighter-pen background + Caveat handwritten comment + squiggly arrow).
- Caveat is loaded from Google Fonts alongside Bricolage so handwritten annotations render even on first visit.

## What's not in this PR
- The flagship demo post (`src/posts/2026-04-16-in-search-of-the-agent-ide.md`) is intentionally excluded and stays in the working tree for now.
- `{% statblock %}` shortcode removed before commit — not shipping in this PR.

## Known limitation
Annotations currently stay inline on every breakpoint because the `xl+` right margin is occupied by the existing Outline + Join-the-Conversation sidebar. A TODO has been added under "Editorial Mode" in `docs/TODO.md` capturing the conflict and three possible resolutions (per-post `marginalia` toggle, JS line measurer, or a dedicated annotation gutter).

## Test plan
- [ ] Run `npm run build` — production build completes clean
- [ ] Add `theme: editorial` to a test post, confirm the drop cap renders on the first paragraph and nothing else changes
- [ ] Add `sidebar:` frontmatter with `label` / `title` / `content`, confirm the panel renders above the author card on `xl+` screens
- [ ] Wrap a wide markdown table in `{% wide %}...{% endwide %}`, verify it breaks out of the article container with viewport padding and that long-prose columns wrap instead of stretching
- [ ] Drop `{% annotate "comment" %}word{% endannotate %}` inline, confirm the highlight + Caveat comment + squiggly arrow all render and Caveat font is active
- [ ] Use `{% analysis title="...", winner="...", side="a" %}` — verify side-colored border, winner pill, and markdown rendering inside the body
- [ ] Non-editorial posts render unchanged (no drop cap, no sidebar, TOC and comments sidebars still present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)